### PR TITLE
Add localization feature to startup recipe

### DIFF
--- a/DFC.ServiceTaxonomy.Editor/Recipes/Service Taxonomy.recipe.json
+++ b/DFC.ServiceTaxonomy.Editor/Recipes/Service Taxonomy.recipe.json
@@ -25,6 +25,7 @@
                 "OrchardCore.Diagnostics",
                 "OrchardCore.DynamicCache",
                 "OrchardCore.Features",
+                "OrchardCore.Localization",
                 "OrchardCore.Navigation",
                 "OrchardCore.Recipes",
                 "OrchardCore.Resources",


### PR DESCRIPTION
Attempt at fixing issue where unable to display content types and content on a machine set up with uk language/culture.

(Unable to reproduce on dev machine after setting all culture to UK and removing all US!)