### PR TITLE
DFCC-659 Fix grab bag

### DIFF
--- a/DFC.ServiceTaxonomy.GraphSync/Extensions/MergeNodeExtensions.cs
+++ b/DFC.ServiceTaxonomy.GraphSync/Extensions/MergeNodeExtensions.cs
@@ -91,5 +91,27 @@ namespace DFC.ServiceTaxonomy.GraphSync.Extensions
 
             return values;
         }
+
+        public static string[] AddArrayPropertyFromMultilineString(
+            this IMergeNodeCommand mergeNodeCommand,
+            string nodePropertyName,
+            JObject content,
+            string contentPropertyName)
+        {
+            string[]? valueStrings;
+            JToken? values = content[contentPropertyName];
+            if (values != null && values.Type != JTokenType.Null)
+            {
+                valueStrings = values.Value<string>().Split("\r\n");
+            }
+            else
+            {
+                valueStrings = new string[0];
+            }
+
+            mergeNodeCommand.Properties.Add(nodePropertyName, valueStrings);
+
+            return valueStrings;
+        }
     }
 }

--- a/DFC.ServiceTaxonomy.GraphSync/GraphSyncers/Fields/TaxonomyFieldGraphSyncer.cs
+++ b/DFC.ServiceTaxonomy.GraphSync/GraphSyncers/Fields/TaxonomyFieldGraphSyncer.cs
@@ -102,7 +102,8 @@ namespace DFC.ServiceTaxonomy.GraphSync.GraphSyncers.Fields
             //using var _ = graphSyncHelper.PushPropertyNameTransform(_taxonomyPropertyNameTransform);
 
             //todo: this is there sometimes, but not others (Tag editor is selected and/or non-unique?)
-            context.MergeNodeCommand.AddArrayProperty<string>(TaxonomyTermsNodePropertyName, contentItemField, TagNames);
+            // find out when it should be there: need to know to know how to validate it
+            //context.MergeNodeCommand.AddArrayProperty<string>(TaxonomyTermsNodePropertyName, contentItemField, TagNames);
 
             //todo: need to store location as string, e.g. "/contact-us"
             // could alter flatten to also include parent and work backwards
@@ -205,11 +206,13 @@ namespace DFC.ServiceTaxonomy.GraphSync.GraphSyncers.Fields
                 context.ExpectedRelationshipCounts.IncreaseCount(termRelationshipType);
             }
 
-            return context.GraphValidationHelper.StringArrayContentPropertyMatchesNodeProperty(
-                TagNames,
-                contentItemField,
-                TaxonomyTermsNodePropertyName,
-                context.NodeWithOutgoingRelationships.SourceNode);
+            // return context.GraphValidationHelper.StringArrayContentPropertyMatchesNodeProperty(
+            //     TagNames,
+            //     contentItemField,
+            //     TaxonomyTermsNodePropertyName,
+            //     context.NodeWithOutgoingRelationships.SourceNode);
+
+            return (true, "");
         }
     }
 }

--- a/DFC.ServiceTaxonomy.GraphSync/GraphSyncers/Fields/TextFieldGraphSyncer.cs
+++ b/DFC.ServiceTaxonomy.GraphSync/GraphSyncers/Fields/TextFieldGraphSyncer.cs
@@ -21,6 +21,7 @@ namespace DFC.ServiceTaxonomy.GraphSync.GraphSyncers.Fields
 
             if (settings != null && settings.GetSettings<TextFieldSettings>().Hint != null && settings.GetSettings<TextFieldSettings>().Hint!.ToLower().IndexOf("##synctoarray") != -1)
             {
+                //todo: fix empty string case : add helper
                 var val = contentItemField[ContentKey]!.ToString().Split("\r\n");
                 var array = JArray.FromObject(val);
                 context.MergeNodeCommand.AddArrayProperty<string>(nodePropertyName, array);
@@ -35,6 +36,7 @@ namespace DFC.ServiceTaxonomy.GraphSync.GraphSyncers.Fields
         {
             string nodePropertyName = await context.GraphSyncHelper.PropertyName(context.ContentPartFieldDefinition!.Name);
 
+            //todo: fix validating split string
             return context.GraphValidationHelper.StringContentPropertyMatchesNodeProperty(
                 ContentKey,
                 contentItemField,

--- a/DFC.ServiceTaxonomy.GraphSync/GraphSyncers/Interfaces/IGraphValidationHelper.cs
+++ b/DFC.ServiceTaxonomy.GraphSync/GraphSyncers/Interfaces/IGraphValidationHelper.cs
@@ -28,6 +28,12 @@ namespace DFC.ServiceTaxonomy.GraphSync.GraphSyncers.Interfaces
             string nodePropertyName,
             INode sourceNode);
 
+        (bool matched, string failureReason) ContentMultilineStringPropertyMatchesNodeProperty(
+            string contentKey,
+            JObject contentItemField,
+            string nodePropertyName,
+            INode sourceNode);
+
         (bool matched, string failureReason) StringContentPropertyMatchesNodeProperty(
             string contentKey,
             JObject contentItemField,

--- a/DFC.ServiceTaxonomy.PageLocation/GraphSyncers/PageLocationPartGraphSyncer.cs
+++ b/DFC.ServiceTaxonomy.PageLocation/GraphSyncers/PageLocationPartGraphSyncer.cs
@@ -28,19 +28,9 @@ namespace DFC.ServiceTaxonomy.PageLocation.GraphSyncers
             context.MergeNodeCommand.AddProperty<bool>(await context.GraphSyncHelper.PropertyName(DefaultPageForLocationPropertyName), content, DefaultPageForLocationPropertyName);
             context.MergeNodeCommand.AddProperty<string>(await context.GraphSyncHelper.PropertyName(FullUrlPropertyName), content, FullUrlPropertyName);
 
-            JArray? redirectLocationsJArray;
-            JToken? redirectLocations = content["RedirectLocations"];
-            if (redirectLocations != null && redirectLocations.Type != JTokenType.Null)
-            {
-                var redirectLocationsArray = redirectLocations.Value<string>().Split("\r\n");
-                redirectLocationsJArray = JArray.FromObject(redirectLocationsArray);
-            }
-            else
-            {
-                redirectLocationsJArray = new JArray();
-            }
-
-            context.MergeNodeCommand.AddArrayProperty<string>(await context.GraphSyncHelper.PropertyName(RedirectLocationsPropertyName), redirectLocationsJArray);
+            context.MergeNodeCommand.AddArrayPropertyFromMultilineString(
+                await context.GraphSyncHelper.PropertyName(RedirectLocationsPropertyName), content,
+                RedirectLocationsPropertyName);
         }
 
         public async Task<(bool validated, string failureReason)> ValidateSyncComponent(JObject content,

--- a/DFC.ServiceTaxonomy.PageLocation/GraphSyncers/PageLocationPartGraphSyncer.cs
+++ b/DFC.ServiceTaxonomy.PageLocation/GraphSyncers/PageLocationPartGraphSyncer.cs
@@ -28,13 +28,19 @@ namespace DFC.ServiceTaxonomy.PageLocation.GraphSyncers
             context.MergeNodeCommand.AddProperty<bool>(await context.GraphSyncHelper.PropertyName(DefaultPageForLocationPropertyName), content, DefaultPageForLocationPropertyName);
             context.MergeNodeCommand.AddProperty<string>(await context.GraphSyncHelper.PropertyName(FullUrlPropertyName), content, FullUrlPropertyName);
 
-            var val = content["RedirectLocations"]?.ToString().Split("\r\n");
-
-            if (val != null)
+            JArray? redirectLocationsJArray;
+            JToken? redirectLocations = content["RedirectLocations"];
+            if (redirectLocations != null && redirectLocations.Type != JTokenType.Null)
             {
-                var array = JArray.FromObject(val);
-                context.MergeNodeCommand.AddArrayProperty<string>(await context.GraphSyncHelper.PropertyName(RedirectLocationsPropertyName), array);
+                var redirectLocationsArray = redirectLocations.Value<string>().Split("\r\n");
+                redirectLocationsJArray = JArray.FromObject(redirectLocationsArray);
             }
+            else
+            {
+                redirectLocationsJArray = new JArray();
+            }
+
+            context.MergeNodeCommand.AddArrayProperty<string>(await context.GraphSyncHelper.PropertyName(RedirectLocationsPropertyName), redirectLocationsJArray);
         }
 
         public async Task<(bool validated, string failureReason)> ValidateSyncComponent(JObject content,

--- a/DFC.ServiceTaxonomy.PageLocation/GraphSyncers/PageLocationPartGraphSyncer.cs
+++ b/DFC.ServiceTaxonomy.PageLocation/GraphSyncers/PageLocationPartGraphSyncer.cs
@@ -65,7 +65,7 @@ namespace DFC.ServiceTaxonomy.PageLocation.GraphSyncers
             if (!matched)
                 return (false, $"{FullUrlPropertyName} did not validate: {failureReason}");
 
-            (matched, failureReason) = context.GraphValidationHelper.StringArrayContentPropertyMatchesNodeProperty(
+            (matched, failureReason) = context.GraphValidationHelper.ContentMultilineStringPropertyMatchesNodeProperty(
                 RedirectLocationsPropertyName,
                 content,
                 await context.GraphSyncHelper.PropertyName(RedirectLocationsPropertyName),

--- a/DFC.ServiceTaxonomy.PageLocation/Handlers/DefaultPageLocationsContentHandler.cs
+++ b/DFC.ServiceTaxonomy.PageLocation/Handlers/DefaultPageLocationsContentHandler.cs
@@ -15,6 +15,7 @@ using YesSql;
 
 namespace DFC.ServiceTaxonomy.PageLocation.Handlers
 {
+    //todo: IContentPartHandler now has support for DraftSavedAsync, so we should switch to using it
     public class DefaultPageLocationsContentHandler : ContentHandlerBase
     {
         private readonly IServiceProvider _serviceProvider;

--- a/DeveloperNotes.md
+++ b/DeveloperNotes.md
@@ -2,6 +2,8 @@
 
 * sync contentitemid (& contentitemversion) into graphs?
 
+* move page flow into own tab, so have Metadata, Content and SEO?
+
 * wysiwyg alignment in flow part (if we need to support justification)
 
 * the validation needs to de-substitute the actual urls back to <<contentapiprefix>> before it checks for equality


### PR DESCRIPTION
### Fixes
* Fix page redirect locations (and general multiline text to array) syncing when there are no lines
* Fix page redirect locations (and general multiline text to array) sync validation
* Don't sync or validate taxonomy tag names (they're only there under some circumstances, so don't sync or validate them for now)