### PR TITLE
DFCC-839 Fix and improve sync sanity checking

### DIFF
--- a/DFC.ServiceTaxonomy.GraphSync/GraphSyncers/MergeGraphSyncer.cs
+++ b/DFC.ServiceTaxonomy.GraphSync/GraphSyncers/MergeGraphSyncer.cs
@@ -209,6 +209,11 @@ namespace DFC.ServiceTaxonomy.GraphSync.GraphSyncers
             if (graphReplicaSet.Name != GraphReplicaSetNames.Published)
                 return Enumerable.Empty<INodeWithOutgoingRelationships>();
 
+            //todo: only need to do this if there's only currently just a draft version
+            // might have to pass contentitem from event instead of fetching
+            // (doing it unnecessarily might mess up the incoming relationships
+            // and depends on whether published or preview is synced first!)
+
             IGetIncomingContentPickerRelationshipsQuery getDraftRelationshipsQuery =
                 _serviceProvider.GetRequiredService<IGetIncomingContentPickerRelationshipsQuery>();
 


### PR DESCRIPTION
If we don't clear down the existing relationships first, only check that the number of relationships doesn't exceed the maximum possible.
Also, introduce a check that the number of relationships created doesn't exceed the maximum possible when creating two way relationships.