### PR TITLE
DFCC-909 Fix sync issue

### DIFF
--- a/DFC.ServiceTaxonomy.Content/Services/ContentItemsService.cs
+++ b/DFC.ServiceTaxonomy.Content/Services/ContentItemsService.cs
@@ -8,7 +8,6 @@ using YesSql;
 
 namespace DFC.ServiceTaxonomy.Content.Services
 {
-    //todo: better name
     public class ContentItemsService : IContentItemsService
     {
         private readonly ISession _session;

--- a/DFC.ServiceTaxonomy.GraphSync/GraphSyncers/ValidateAndRepairGraph.cs
+++ b/DFC.ServiceTaxonomy.GraphSync/GraphSyncers/ValidateAndRepairGraph.cs
@@ -241,7 +241,7 @@ namespace DFC.ServiceTaxonomy.GraphSync.GraphSyncers
             ValidateAndRepairResult result)
         {
             _logger.LogWarning(
-                "Content items of type {ContentTypeDefinitionName} failed validation (ValidationFailures}). Attempting to repair them.",
+                "Content items of type {ContentTypeDefinitionName} failed validation ({ValidationFailures}). Attempting to repair them.",
                 contentTypeDefinition.Name,
                 string.Join(", ", syncValidationFailures.Select(f => f.ContentItem.ToString())));
 

--- a/DFC.ServiceTaxonomy.UnitTests/GraphSync/GraphSyncers/Fields/ContentPickerFieldGraphSyncerTests/ContentPickerFieldGraphSyncerAddSyncComponentsTestsBase.cs
+++ b/DFC.ServiceTaxonomy.UnitTests/GraphSync/GraphSyncers/Fields/ContentPickerFieldGraphSyncerTests/ContentPickerFieldGraphSyncerAddSyncComponentsTestsBase.cs
@@ -4,7 +4,6 @@ using DFC.ServiceTaxonomy.GraphSync.GraphSyncers.Interfaces.ContentItemVersions;
 using FakeItEasy;
 using Microsoft.Extensions.Logging;
 using OrchardCore.ContentFields.Settings;
-using OrchardCore.ContentManagement.Metadata;
 
 namespace DFC.ServiceTaxonomy.UnitTests.GraphSync.GraphSyncers.Fields.ContentPickerFieldGraphSyncerTests
 {
@@ -16,7 +15,9 @@ namespace DFC.ServiceTaxonomy.UnitTests.GraphSync.GraphSyncers.Fields.ContentPic
         public ContentPickerFieldGraphSyncerAddSyncComponentsTestsBase()
         {
             Logger = A.Fake<ILogger<ContentPickerFieldGraphSyncer>>();
-            ContentFieldGraphSyncer = new ContentPickerFieldGraphSyncer(A.Fake<IPreExistingContentItemVersion>(), A.Fake<IContentDefinitionManager>(), A.Fake<IServiceProvider>());
+            ContentFieldGraphSyncer = new ContentPickerFieldGraphSyncer(
+                A.Fake<IPreExistingContentItemVersion>(),
+                A.Fake<IServiceProvider>());
 
             ContentPickerFieldSettings = A.Fake<ContentPickerFieldSettings>();
 

--- a/DFC.ServiceTaxonomy.UnitTests/GraphSync/GraphSyncers/Fields/ContentPickerFieldGraphSyncerTests/ContentPickerFieldGraphSyncerValidateSyncComponentTestsBase.cs
+++ b/DFC.ServiceTaxonomy.UnitTests/GraphSync/GraphSyncers/Fields/ContentPickerFieldGraphSyncerTests/ContentPickerFieldGraphSyncerValidateSyncComponentTestsBase.cs
@@ -2,7 +2,6 @@
 using DFC.ServiceTaxonomy.GraphSync.GraphSyncers.Fields;
 using DFC.ServiceTaxonomy.GraphSync.GraphSyncers.Interfaces.ContentItemVersions;
 using FakeItEasy;
-using OrchardCore.ContentManagement.Metadata;
 
 namespace DFC.ServiceTaxonomy.UnitTests.GraphSync.GraphSyncers.Fields.ContentPickerFieldGraphSyncerTests
 {
@@ -12,7 +11,7 @@ namespace DFC.ServiceTaxonomy.UnitTests.GraphSync.GraphSyncers.Fields.ContentPic
 
         public ContentPickerFieldGraphSyncerValidateSyncComponentTestsBase()
         {
-            ContentFieldGraphSyncer = new ContentPickerFieldGraphSyncer(A.Fake<IPreExistingContentItemVersion>(), A.Fake<IContentDefinitionManager>(), A.Fake<IServiceProvider>());
+            ContentFieldGraphSyncer = new ContentPickerFieldGraphSyncer(A.Fake<IPreExistingContentItemVersion>(), A.Fake<IServiceProvider>());
         }
 
         //todo: tests

--- a/DeveloperNotes.md
+++ b/DeveloperNotes.md
@@ -2,6 +2,30 @@
 
 * need to test branch, not master!
 
+* visualiser..
+
+// settings min degrees, max degrees, max nodes
+// 1st pass all relations/bags
+// 2+ pass all relations/bags:
+//   if node already encountered, add relationship, don't follow further
+//   if content type already encountered, don't add node or relationship, don't follow further???
+// if 2+ pass takes nodes past max nodes, don't add any of pass (will need to stage)
+// ignore maxnodes for 1 degree??
+
+will interact with webvowl doing something similar...
+`The number of visualized elements has been automatically reduced.`
+
+
+* should skill and occupation labels be creatable?
+
+* section break's have broke - they look wrong in the html editor
+
+* revisit recipes following idempotent recipes changes. create/import? create generates new ids(?) find different way to disable sync
+see https://github.com/OrchardCMS/OrchardCore/pull/5487
+https://github.com/OrchardCMS/OrchardCore/issues/1970
+
+* check config asap at startup and check for presence of __placeholders__ (or missing/bad config in general) still in config
+
 * move common field syncing such as modified/created/contentitemid to graphsyncpart?
 
 * disable cloning taxonomies?? backdoor to creating a draft taxonomy (although it works, so perhaps we leave it)


### PR DESCRIPTION
Fixes reported scenario...

> published shared content on draft page... 
> 
> add new draft of shared content.... 
> 
> publish page
> 
> Outcome:
> The page widget doesn't get a relationship to the shared content in the published graph

Also fixes validation and repair by
* fixing a bad log line
* making validation and repair aware of the new ordinal relationship property added by the content picker