### PR TITLE
Allow draft content items to be indexed by the TaxonomyIndex

### DIFF
--- a/DFC.ServiceTaxonomy.Taxonomies/Indexing/TaxonomyIndex.cs
+++ b/DFC.ServiceTaxonomy.Taxonomies/Indexing/TaxonomyIndex.cs
@@ -37,11 +37,6 @@ namespace DFC.ServiceTaxonomy.Taxonomies.Indexing
             context.For<TaxonomyIndex>()
                 .Map(contentItem =>
                 {
-                    if (!contentItem.IsPublished())
-                    {
-                        return null;
-                    }
-
                     // Can we safely ignore this content item?
                     if (_ignoredTypes.Contains(contentItem.ContentType))
                     {


### PR DESCRIPTION
Allow draft pages to be indexed by the taxonomy index so they appear when filtering in the admin list