### PR TITLE
Import improvements

### DIFF
--- a/DFC.ServiceTaxonomy.Editor/NLog.dev.config
+++ b/DFC.ServiceTaxonomy.Editor/NLog.dev.config
@@ -33,6 +33,7 @@
         <logger name="DFC.ServiceTaxonomy.GraphSync.GraphSyncers.DeleteGraphSyncer" minlevel="Info" writeTo="file" />
         <logger name="DFC.ServiceTaxonomy.Neo4j.Log.NeoLogger" minlevel="Info" writeTo="file" />
         <logger name="DFC.ServiceTaxonomy.Neo4j.Services.NeoGraphDatabase" minlevel="Info" writeTo="file" />
+        <logger name="DFC.ServiceTaxonomy.GraphSync.Recipes.Executors.ContentNoCacheStep" minlevel="Info" writeTo="file" />
         <logger name="DFC.ServiceTaxonomy.GraphSync.Recipes.Executors.CypherCommandStep" minlevel="Info" writeTo="file" />
         <logger name="DFC.ServiceTaxonomy.GraphSync.Recipes.Executors.CypherToContentStep" minlevel="Info" writeTo="file" />
         <logger name="DFC.ServiceTaxonomy.Events.Services.EventGridContentClient" minlevel="Info" writeTo="file" />

--- a/DFC.ServiceTaxonomy.Editor/NLog.dev.config
+++ b/DFC.ServiceTaxonomy.Editor/NLog.dev.config
@@ -36,6 +36,7 @@
         <logger name="DFC.ServiceTaxonomy.GraphSync.Recipes.Executors.ContentNoCacheStep" minlevel="Info" writeTo="file" />
         <logger name="DFC.ServiceTaxonomy.GraphSync.Recipes.Executors.CypherCommandStep" minlevel="Info" writeTo="file" />
         <logger name="DFC.ServiceTaxonomy.GraphSync.Recipes.Executors.CypherToContentStep" minlevel="Info" writeTo="file" />
+        <logger name="DFC.ServiceTaxonomy.GraphSync.Recipes.Executors.CSharpContentStep" minlevel="Info" writeTo="file" />
         <logger name="DFC.ServiceTaxonomy.Events.Services.EventGridContentClient" minlevel="Info" writeTo="file" />
         <logger name="DFC.ServiceTaxonomy.GraphSync.GraphSyncers.MergeGraphSyncer" minlevel="Debug" writeTo="file" />
         <logger name="DFC.ServiceTaxonomy.GraphSync.GraphSyncers.Parts.Flow.FlowPartEmbeddedContentItemsGraphSyncer" minlevel="Debug" writeTo="file" />

--- a/DFC.ServiceTaxonomy.GraphSync/GraphSyncers/Helpers/ContentFieldsGraphSyncer.cs
+++ b/DFC.ServiceTaxonomy.GraphSync/GraphSyncers/Helpers/ContentFieldsGraphSyncer.cs
@@ -101,6 +101,7 @@ namespace DFC.ServiceTaxonomy.GraphSync.GraphSyncers.Helpers
                     }
                     else
                     {
+                        //todo: casting to object? (unexpectedly) throws if null, so either use 'as' (and log a warning) or let it throw if content is missing. does the field definition say if its required or not? if so, go on that - don't want to silently let through e.g. importing a jp without an occupation - it'll just fail downstream. better to fail fast
                         JObject? contentItemField = (JObject?)content[contentPartFieldDefinition.Name];
                         if (contentItemField == null)
                             continue;

--- a/DFC.ServiceTaxonomy.GraphSync/GraphSyncers/Helpers/ContentFieldsGraphSyncer.cs
+++ b/DFC.ServiceTaxonomy.GraphSync/GraphSyncers/Helpers/ContentFieldsGraphSyncer.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using DFC.ServiceTaxonomy.GraphSync.GraphSyncers.Exceptions;
 using DFC.ServiceTaxonomy.GraphSync.GraphSyncers.Interfaces.Contexts;
 using DFC.ServiceTaxonomy.GraphSync.GraphSyncers.Interfaces.Fields;
 using DFC.ServiceTaxonomy.GraphSync.GraphSyncers.Interfaces.Helpers;
@@ -101,10 +102,11 @@ namespace DFC.ServiceTaxonomy.GraphSync.GraphSyncers.Helpers
                     }
                     else
                     {
-                        //todo: casting to object? (unexpectedly) throws if null, so either use 'as' (and log a warning) or let it throw if content is missing. does the field definition say if its required or not? if so, go on that - don't want to silently let through e.g. importing a jp without an occupation - it'll just fail downstream. better to fail fast
-                        JObject? contentItemField = (JObject?)content[contentPartFieldDefinition.Name];
+                        JObject? contentItemField = content[contentPartFieldDefinition.Name] as JObject;
                         if (contentItemField == null)
-                            continue;
+                        {
+                            throw new GraphSyncException($"The '{context.ContentItem.DisplayText}' {context.ContentItem.ContentType} is missing content for the {contentPartFieldDefinition.Name} {contentPartFieldDefinition.FieldDefinition.Name}.");
+                        }
 
                         await contentFieldGraphSyncer.AddSyncComponents(contentItemField, context);
                     }

--- a/DFC.ServiceTaxonomy.GraphSync/GraphSyncers/MergeGraphSyncer.cs
+++ b/DFC.ServiceTaxonomy.GraphSync/GraphSyncers/MergeGraphSyncer.cs
@@ -19,7 +19,6 @@ using DFC.ServiceTaxonomy.GraphSync.Models;
 using DFC.ServiceTaxonomy.GraphSync.Neo4j.Queries.Interfaces;
 using DFC.ServiceTaxonomy.Neo4j.Commands.Interfaces;
 using DFC.ServiceTaxonomy.Neo4j.Services.Interfaces;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using MoreLinq;
@@ -34,7 +33,6 @@ namespace DFC.ServiceTaxonomy.GraphSync.GraphSyncers
         private readonly IGraphSyncPartGraphSyncer _graphSyncPartGraphSyncer;
         private readonly ISyncNameProvider _syncNameProvider;
         private readonly IReplaceRelationshipsCommand _replaceRelationshipsCommand;
-        private readonly IMemoryCache _memoryCache;
         private readonly IContentItemVersionFactory _contentItemVersionFactory;
         private readonly IPublishedContentItemVersion _publishedContentItemVersion;
         private readonly IPreviewContentItemVersion _previewContentItemVersion;
@@ -60,7 +58,6 @@ namespace DFC.ServiceTaxonomy.GraphSync.GraphSyncers
             ISyncNameProvider syncNameProvider,
             IMergeNodeCommand mergeNodeCommand,
             IReplaceRelationshipsCommand replaceRelationshipsCommand,
-            IMemoryCache memoryCache,
             IContentItemVersionFactory contentItemVersionFactory,
             IPublishedContentItemVersion publishedContentItemVersion,
             IPreviewContentItemVersion previewContentItemVersion,
@@ -74,7 +71,6 @@ namespace DFC.ServiceTaxonomy.GraphSync.GraphSyncers
             _syncNameProvider = syncNameProvider;
             MergeNodeCommand = mergeNodeCommand;
             _replaceRelationshipsCommand = replaceRelationshipsCommand;
-            _memoryCache = memoryCache;
             _contentItemVersionFactory = contentItemVersionFactory;
             _publishedContentItemVersion = publishedContentItemVersion;
             _previewContentItemVersion = previewContentItemVersion;
@@ -115,13 +111,13 @@ namespace DFC.ServiceTaxonomy.GraphSync.GraphSyncers
             if (graphSyncPartContent == null)
                 return AllowSync.NotRequired;
 
-            string? disableSyncContentItemVersionId = _memoryCache.Get<string>($"DisableSync_{contentItem.ContentItemVersionId}");
-            if (disableSyncContentItemVersionId != null)
-            {
-                _logger.LogInformation("Not syncing {ContentType}:{ContentItemId}, version {ContentItemVersionId} as syncing has been disabled for it.",
-                    contentItem.ContentType, contentItem.ContentItemId, disableSyncContentItemVersionId);
-                return AllowSync.NotRequired;
-            }
+            // string? disableSyncContentItemVersionId = _memoryCache.Get<string>($"DisableSync_{contentItem.ContentItemVersionId}");
+            // if (disableSyncContentItemVersionId != null)
+            // {
+            //     _logger.LogInformation("Not syncing {ContentType}:{ContentItemId}, version {ContentItemVersionId} as syncing has been disabled for it.",
+            //         contentItem.ContentType, contentItem.ContentItemId, disableSyncContentItemVersionId);
+            //     return AllowSync.NotRequired;
+            // }
 
             //todo: ContentType belongs in the context, either combine helper & context, or supply context to helper?
             _syncNameProvider.ContentType = contentItem.ContentType;

--- a/DFC.ServiceTaxonomy.GraphSync/GraphSyncers/MergeGraphSyncer.cs
+++ b/DFC.ServiceTaxonomy.GraphSync/GraphSyncers/MergeGraphSyncer.cs
@@ -111,14 +111,6 @@ namespace DFC.ServiceTaxonomy.GraphSync.GraphSyncers
             if (graphSyncPartContent == null)
                 return AllowSync.NotRequired;
 
-            // string? disableSyncContentItemVersionId = _memoryCache.Get<string>($"DisableSync_{contentItem.ContentItemVersionId}");
-            // if (disableSyncContentItemVersionId != null)
-            // {
-            //     _logger.LogInformation("Not syncing {ContentType}:{ContentItemId}, version {ContentItemVersionId} as syncing has been disabled for it.",
-            //         contentItem.ContentType, contentItem.ContentItemId, disableSyncContentItemVersionId);
-            //     return AllowSync.NotRequired;
-            // }
-
             //todo: ContentType belongs in the context, either combine helper & context, or supply context to helper?
             _syncNameProvider.ContentType = contentItem.ContentType;
 

--- a/DFC.ServiceTaxonomy.GraphSync/Recipes/Executors/ContentNoCacheStep.cs
+++ b/DFC.ServiceTaxonomy.GraphSync/Recipes/Executors/ContentNoCacheStep.cs
@@ -70,6 +70,7 @@ namespace DFC.ServiceTaxonomy.GraphSync.Recipes.Executors
 
                 _logger.LogInformation("Created content items in {TimeTaken}.", stopwatch.Elapsed);
 
+                //todo: should we still collect?
 #pragma warning disable S1215
                 GC.Collect();
 #pragma warning restore S1215

--- a/DFC.ServiceTaxonomy.GraphSync/Recipes/Executors/ContentNoCacheStep.cs
+++ b/DFC.ServiceTaxonomy.GraphSync/Recipes/Executors/ContentNoCacheStep.cs
@@ -59,6 +59,8 @@ namespace DFC.ServiceTaxonomy.GraphSync.Recipes.Executors
 
                     _session.Save(contentItem);
 
+//todo: call graph sync directly
+
                     // DateTime? modifiedUtc = contentItem.ModifiedUtc;
                     // DateTime? publishedUtc = contentItem.PublishedUtc;
                     // ContentItem? existing = await _contentManager.GetVersionAsync(contentItem.ContentItemVersionId);

--- a/DFC.ServiceTaxonomy.GraphSync/Recipes/Executors/ContentNoCacheStep.cs
+++ b/DFC.ServiceTaxonomy.GraphSync/Recipes/Executors/ContentNoCacheStep.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
+using DFC.ServiceTaxonomy.GraphSync.Orchestrators.Interfaces;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
 using OrchardCore.ContentManagement;
@@ -13,7 +14,10 @@ namespace DFC.ServiceTaxonomy.GraphSync.Recipes.Executors
     //todo: look for more ways to keep memory down and speed up the import
     // e.g. we could replicate CreateAsync, and not add the item to the cache and take out what isn't necessary
     /// <summary>
-    /// This recipe step creates a set of content items, without adding the content item to the ContentManagerSession cache, to keep memory usage down.
+    /// This recipe step creates a set of content items,
+    /// without adding the content item to the ContentManagerSession cache (to keep memory usage down)
+    /// or running any content handlers (for speed).
+    /// It does however sync the items to the appropriate graphs.
     /// Ideally we should merge this and CSharpContentStep into a single step, but if we did that, most recipes
     /// (that don't require csharp scripting) would pay an unnecessary time and memory cost, so for now, we have
     /// two separate step handlers.
@@ -21,23 +25,26 @@ namespace DFC.ServiceTaxonomy.GraphSync.Recipes.Executors
     public class ContentNoCacheStep : IRecipeStepHandler
     {
         private readonly ISession _session;
+        private readonly ISyncOrchestrator _syncOrchestrator;
         private readonly ILogger<ContentNoCacheStep> _logger;
 
         public const string StepName = "ContentNoCache";
 
         public ContentNoCacheStep(
             ISession session,
+            ISyncOrchestrator syncOrchestrator,
             ILogger<ContentNoCacheStep> logger)
         {
             _session = session;
+            _syncOrchestrator = syncOrchestrator;
             _logger = logger;
         }
 
-        public Task ExecuteAsync(RecipeExecutionContext context)
+        public async Task ExecuteAsync(RecipeExecutionContext context)
         {
             if (!string.Equals(context.Name, StepName, StringComparison.OrdinalIgnoreCase))
             {
-                return Task.CompletedTask;
+                return;
             }
 
             try
@@ -47,7 +54,7 @@ namespace DFC.ServiceTaxonomy.GraphSync.Recipes.Executors
                 ContentStepModel? model = context.Step.ToObject<ContentStepModel>();
                 JArray? data = model?.Data;
                 if (data == null)
-                    return Task.CompletedTask;
+                    return;
 
                 foreach (JToken? token in data)
                 {
@@ -58,31 +65,7 @@ namespace DFC.ServiceTaxonomy.GraphSync.Recipes.Executors
                     // assume item doesn't currently exist (for speed!)
 
                     _session.Save(contentItem);
-
-//todo: call graph sync directly
-
-                    // DateTime? modifiedUtc = contentItem.ModifiedUtc;
-                    // DateTime? publishedUtc = contentItem.PublishedUtc;
-                    // ContentItem? existing = await _contentManager.GetVersionAsync(contentItem.ContentItemVersionId);
-                    //
-                    // if (existing == null)
-                    // {
-                    //     // Initializes the Id as it could be interpreted as an updated object when added back to YesSql
-                    //     contentItem.Id = 0;
-                    //     await _contentManager.CreateAsync(contentItem);
-                    //     _contentManagerSession.Clear();
-                    //
-                    //     // Overwrite ModifiedUtc & PublishedUtc values that handlers have changes
-                    //     // Should not be necessary if IContentManager had an Import method
-                    //     contentItem.ModifiedUtc = modifiedUtc;
-                    //     contentItem.PublishedUtc = publishedUtc;
-                    // }
-                    // else
-                    // {
-                    //     // Replaces the id to force the current item to be updated
-                    //     existing.Id = contentItem.Id;
-                    //     _session.Save(existing);
-                    // }
+                    await _syncOrchestrator.Publish(contentItem);
                 }
 
                 _logger.LogInformation("Created content items in {TimeTaken}.", stopwatch.Elapsed);
@@ -90,8 +73,6 @@ namespace DFC.ServiceTaxonomy.GraphSync.Recipes.Executors
 #pragma warning disable S1215
                 GC.Collect();
 #pragma warning restore S1215
-
-                return Task.CompletedTask;
             }
             catch (Exception ex)
             {

--- a/DFC.ServiceTaxonomy.GraphSync/Recipes/Executors/CypherToContentStep.cs
+++ b/DFC.ServiceTaxonomy.GraphSync/Recipes/Executors/CypherToContentStep.cs
@@ -174,20 +174,6 @@ namespace DFC.ServiceTaxonomy.GraphSync.Recipes.Executors
 
         private async Task CreateContentItem(ContentItem contentItem)
         {
-            //todo: could put contenttype in there for extra safety!? overkill?
-
-            // if the cache expires before the sync gets called, that's fine as its only an optimisation
-            // to not sync the content item. if it's synced, the graph will still be correct
-            // (we're essentially skipping a no-op)
-            // what we want to avoid, is _not_ syncing when we should
-            // that's why we use ContentItemVersionId, instead of ContentItemId
-            // if (!syncBackRequired)
-            // {
-            //     string cacheKey = $"DisableSync_{contentItem.ContentItemVersionId}";
-            //     _memoryCache.Set(cacheKey, contentItem.ContentItemVersionId,
-            //         new TimeSpan(0, 0, 30));
-            // }
-
             //todo: log adding content type + id? how would we (easily) get the contenttype??
 
             await _contentManager.CreateAsync(contentItem);

--- a/DFC.ServiceTaxonomy.GraphSync/Recipes/Executors/CypherToContentStep.cs
+++ b/DFC.ServiceTaxonomy.GraphSync/Recipes/Executors/CypherToContentStep.cs
@@ -13,7 +13,6 @@ using DFC.ServiceTaxonomy.GraphSync.Neo4j.Queries.Interfaces;
 using DFC.ServiceTaxonomy.Neo4j.Services.Interfaces;
 using Microsoft.CodeAnalysis.CSharp.Scripting;
 using Microsoft.CodeAnalysis.Scripting;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
@@ -36,16 +35,15 @@ namespace DFC.ServiceTaxonomy.GraphSync.Recipes.Executors
     {
         private readonly IGraphCluster _graphCluster;
         private readonly IServiceProvider _serviceProvider;
-        private readonly IContentManager _contentManager;
-        private readonly IContentManagerSession _contentManagerSession;
         private readonly IContentItemIdGenerator _idGenerator;
         private readonly ICypherToContentCSharpScriptGlobals _cypherToContentCSharpScriptGlobals;
         private readonly ISyncNameProvider _syncNameProvider;
         private readonly IPublishedContentItemVersion _publishedContentItemVersion;
         private readonly ISuperpositionContentItemVersion _superpositionContentItemVersion;
         private readonly IEscoContentItemVersion _escoContentItemVersion;
-        private readonly IMemoryCache _memoryCache;
         private readonly ISession _session;
+        private readonly IContentManager _contentManager;
+        private readonly IContentManagerSession _contentManagerSession;
         private readonly ILogger<CypherToContentStep> _logger;
 
         private const string StepName = "CypherToContent";
@@ -53,30 +51,28 @@ namespace DFC.ServiceTaxonomy.GraphSync.Recipes.Executors
         public CypherToContentStep(
             IGraphCluster graphCluster,
             IServiceProvider serviceProvider,
-            IContentManager contentManager,
-            IContentManagerSession contentManagerSession,
             IContentItemIdGenerator idGenerator,
             ICypherToContentCSharpScriptGlobals cypherToContentCSharpScriptGlobals,
             ISyncNameProvider syncNameProvider,
             IPublishedContentItemVersion publishedContentItemVersion,
             ISuperpositionContentItemVersion superpositionContentItemVersion,
             IEscoContentItemVersion escoContentItemVersion,
-            IMemoryCache memoryCache,
             ISession session,
+            IContentManager contentManager,
+            IContentManagerSession contentManagerSession,
             ILogger<CypherToContentStep> logger)
         {
             _graphCluster = graphCluster;
             _serviceProvider = serviceProvider;
-            _contentManager = contentManager;
-            _contentManagerSession = contentManagerSession;
             _idGenerator = idGenerator;
             _cypherToContentCSharpScriptGlobals = cypherToContentCSharpScriptGlobals;
             _syncNameProvider = syncNameProvider;
             _publishedContentItemVersion = publishedContentItemVersion;
             _superpositionContentItemVersion = superpositionContentItemVersion;
             _escoContentItemVersion = escoContentItemVersion;
-            _memoryCache = memoryCache;
             _session = session;
+            _contentManager = contentManager;
+            _contentManagerSession = contentManagerSession;
             _logger = logger;
         }
 
@@ -123,9 +119,14 @@ namespace DFC.ServiceTaxonomy.GraphSync.Recipes.Executors
 
                     foreach (ContentItem preparedContentItem in preparedContentItems)
                     {
-                        //await CreateContentItem(preparedContentItem, cypherToContent.SyncBackRequired);
-                        //await CreatePublishedAsync(preparedContentItem);
-                        _session.Save(preparedContentItem);
+                        if (cypherToContent.SyncBackRequired)
+                        {
+                            await CreateContentItem(preparedContentItem);
+                        }
+                        else
+                        {
+                            _session.Save(preparedContentItem);
+                        }
                     }
 
                     //todo: log this, but ensure no double enumeration
@@ -171,65 +172,27 @@ namespace DFC.ServiceTaxonomy.GraphSync.Recipes.Executors
             return contentItem;
         }
 
-        // private async Task CreateContentItem(ContentItem contentItem, bool syncBackRequired)
-        // {
-        //     //todo: could put contenttype in there for extra safety!? overkill?
-        //
-        //     // if the cache expires before the sync gets called, that's fine as its only an optimisation
-        //     // to not sync the content item. if it's synced, the graph will still be correct
-        //     // (we're essentially skipping a no-op)
-        //     // what we want to avoid, is _not_ syncing when we should
-        //     // that's why we use ContentItemVersionId, instead of ContentItemId
-        //     if (!syncBackRequired)
-        //     {
-        //         string cacheKey = $"DisableSync_{contentItem.ContentItemVersionId}";
-        //         _memoryCache.Set(cacheKey, contentItem.ContentItemVersionId,
-        //             new TimeSpan(0, 0, 30));
-        //     }
-        //
-        //     //todo: log adding content type + id? how would we (easily) get the contenttype??
-        //
-        //     await _contentManager.CreateAsync(contentItem);
-        //     _contentManagerSession.Clear();
-        // }
+        private async Task CreateContentItem(ContentItem contentItem)
+        {
+            //todo: could put contenttype in there for extra safety!? overkill?
 
-        // public async Task CreatePublishedAsync(ContentItem contentItem)
-        // {
-        //     // if (String.IsNullOrEmpty(contentItem.ContentItemVersionId))
-        //     // {
-        //     //     contentItem.ContentItemVersionId = _idGenerator.GenerateUniqueId(contentItem);
-        //     //     contentItem.Published = true;
-        //     //     contentItem.Latest = true;
-        //     // }
-        //
-        //     // Draft flag on create is required for explicitly-published content items
-        //     // if (options.IsDraft)
-        //     // {
-        //     //     contentItem.Published = false;
-        //     // }
-        //
-        //     // Build a context with the initialized instance to create
-        //     // var context = new CreateContentContext(contentItem);
-        //     //
-        //     // // invoke handlers to add information to persistent stores
-        //     // await Handlers.InvokeAsync((handler, context) => handler.CreatingAsync(context), context, _logger);
-        //
-        //     _session.Save(contentItem);
-        //     // _contentManagerSession.Store(contentItem);
-        //
-        //     // await ReversedHandlers.InvokeAsync((handler, context) => handler.CreatedAsync(context), context, _logger);
-        //
-        //     // if (options.IsPublished)
-        //     // {
-        //     //     var publishContext = new PublishContentContext(contentItem, null);
-        //     //
-        //     //     // invoke handlers to acquire state, or at least establish lazy loading callbacks
-        //     //     await Handlers.InvokeAsync((handler, context) => handler.PublishingAsync(context), publishContext, _logger);
-        //     //
-        //     //     // invoke handlers to acquire state, or at least establish lazy loading callbacks
-        //     //     await ReversedHandlers.InvokeAsync((handler, context) => handler.PublishedAsync(context), publishContext, _logger);
-        //     // }
-        // }
+            // if the cache expires before the sync gets called, that's fine as its only an optimisation
+            // to not sync the content item. if it's synced, the graph will still be correct
+            // (we're essentially skipping a no-op)
+            // what we want to avoid, is _not_ syncing when we should
+            // that's why we use ContentItemVersionId, instead of ContentItemId
+            // if (!syncBackRequired)
+            // {
+            //     string cacheKey = $"DisableSync_{contentItem.ContentItemVersionId}";
+            //     _memoryCache.Set(cacheKey, contentItem.ContentItemVersionId,
+            //         new TimeSpan(0, 0, 30));
+            // }
+
+            //todo: log adding content type + id? how would we (easily) get the contenttype??
+
+            await _contentManager.CreateAsync(contentItem);
+            _contentManagerSession.Clear();
+        }
 
         private static readonly Regex _cSharpHelperRegex = new Regex(@"\[c#:([^\]]+)\]", RegexOptions.Compiled);
         private string ReplaceCSharpHelpers(string recipeFragment)

--- a/DeveloperNotes.md
+++ b/DeveloperNotes.md
@@ -1,5 +1,9 @@
 #ToDo
 
+* in the grand tradition of esco always having 1 exception to the rule, 'types of wood materials' is both a skill and knowledge
+  (http://data.europa.eu/esco/skill/fb6f5f61-f3b8-40ba-8363-c8d762325ff7)
+  guessing it shouldn't be a skill
+
 * separate out / show as a deleted item in validate results wwhen a deleted item is validates and don't make into a link that goes nowhere
 
 * use linkgenerator instead of hardcoding in visualiser and validate results, perhaps wrap in service
@@ -621,6 +625,10 @@ match (n:Taxonomy) detach delete n;
 match (n:HTML) detach delete n;
 match (n:HTMLShared) detach delete n;
 :use neo4j;
+
+##Skills of type used by JP
+
+match (jp:JobProfile)-[ro:relatedOccupation]-(o:esco__Occupation)-[rs:esco__relatedOptionalSkill|esco__relatedEssentialSkill]-(s)-[rst:esco__skillType]-(st) where st.skos__prefLabel = 'skill' return count(distinct s)
 
 ##Testing graph validation
 

--- a/GetJobProfiles/ContentRecipes/ContactUsPages.recipe.json
+++ b/GetJobProfiles/ContentRecipes/ContactUsPages.recipe.json
@@ -10,7 +10,7 @@
     "tags": [],
     "steps": [
         {
-            "name": "content",
+            "name": "ContentNoCache",
             "data": [
                 {
                     "ContentItemId": "4yhev1xmryp1mvjkd9693kwqc9",

--- a/GetJobProfiles/ContentRecipes/EmailTemplates.recipe.json
+++ b/GetJobProfiles/ContentRecipes/EmailTemplates.recipe.json
@@ -10,7 +10,7 @@
     "tags": [],
     "steps": [
         {
-            "name": "content",
+            "name": "ContentNoCache",
             "data": [
                 {
                     "ContentItemId": "4kxntsjh5rncv5dqd67q7aaam6",

--- a/GetJobProfiles/ContentRecipes/SharedContent.recipe.json
+++ b/GetJobProfiles/ContentRecipes/SharedContent.recipe.json
@@ -10,7 +10,7 @@
     "tags": [],
     "steps": [
         {
-            "name": "CSharpContent",
+            "name": "ContentNoCache",
             "data": [
                 {
                     "ContentItemId": "4kqbfyyy1ahd5xndf45fg2rad0",

--- a/GetJobProfiles/ContentRecipes/SkillsToolkit.recipe.json
+++ b/GetJobProfiles/ContentRecipes/SkillsToolkit.recipe.json
@@ -10,7 +10,7 @@
     "tags": [],
     "steps": [
         {
-            "name": "CSharpContent",
+            "name": "ContentNoCache",
             "data": [
                 {
                     "ContentItemId": "4bhp0c395zz6hspv6webkhp2dj",

--- a/GetJobProfiles/ContentRecipes/Taxonomies.recipe.json
+++ b/GetJobProfiles/ContentRecipes/Taxonomies.recipe.json
@@ -10,7 +10,7 @@
     "tags": [],
     "steps": [
         {
-            "name": "CSharpContent",
+            "name": "ContentNoCache",
             "data": [
                 {
                     "ContentItemId": "4eembshqzx66drajtdten34tc8",

--- a/GetJobProfiles/ContentRecipes/TestPages.recipe.json
+++ b/GetJobProfiles/ContentRecipes/TestPages.recipe.json
@@ -10,7 +10,7 @@
     "tags": [],
     "steps": [
         {
-            "name": "CSharpContent",
+            "name": "ContentNoCache",
             "data": [
                 {
                     "ContentItemId": "4y795j6arzcqzsy2vng3k553xp",


### PR DESCRIPTION
Recipe import optimisations:
(timings are from dev machine using sqlite, SQL Azure functionality tested but not timed)

* CypherToContent for 400 occupation labels from 1m 3s to 6s
* ContentNoCache for 400 ONet Codes from 1m 7s to 56s
* CSharpContent for 400 ONet Code from 1m 13s to x 56s

Also, switched steps in recipes from Content to ContentNoCache, and CSharpContent to ContentNoCache, which should keep memory down and improve import speeds.