### PR TITLE
Refactor validate and repair screen / use pre-existing node prefix when validating

### DIFF
--- a/DFC.ServiceTaxonomy.GraphSync/Controllers/GraphSyncController.cs
+++ b/DFC.ServiceTaxonomy.GraphSync/Controllers/GraphSyncController.cs
@@ -88,7 +88,8 @@ namespace DFC.ServiceTaxonomy.GraphSync.Controllers
             }
             return View(new TriggerSyncValidationViewModel
             {
-                ValidateAndRepairResults = validateAndRepairResults
+                ValidateAndRepairResults = validateAndRepairResults,
+                Scope = scope
             });
         }
     }

--- a/DFC.ServiceTaxonomy.GraphSync/GraphSyncers/Parts/GraphSyncPartGraphSyncer.cs
+++ b/DFC.ServiceTaxonomy.GraphSync/GraphSyncers/Parts/GraphSyncPartGraphSyncer.cs
@@ -1,14 +1,21 @@
 using System.Threading.Tasks;
+using DFC.ServiceTaxonomy.GraphSync.GraphSyncers.Interfaces.ContentItemVersions;
 using DFC.ServiceTaxonomy.GraphSync.GraphSyncers.Interfaces.Contexts;
 using DFC.ServiceTaxonomy.GraphSync.GraphSyncers.Interfaces.Parts;
 using DFC.ServiceTaxonomy.GraphSync.Models;
 using Newtonsoft.Json.Linq;
-using OrchardCore.ContentManagement;
 
 namespace DFC.ServiceTaxonomy.GraphSync.GraphSyncers.Parts
 {
     public class GraphSyncPartGraphSyncer : ContentPartGraphSyncer, IGraphSyncPartGraphSyncer
     {
+        private readonly IPreExistingContentItemVersion _preExistingContentItemVersion;
+
+        public GraphSyncPartGraphSyncer(IPreExistingContentItemVersion preExistingContentItemVersion)
+        {
+            _preExistingContentItemVersion = preExistingContentItemVersion;
+        }
+
         public override int Priority { get => int.MaxValue; }
         public override string PartName => nameof(GraphSyncPart);
 
@@ -42,6 +49,13 @@ namespace DFC.ServiceTaxonomy.GraphSync.GraphSyncers.Parts
             JObject content,
             IValidateAndRepairContext context)
         {
+            var syncSettings = context.SyncNameProvider.GetGraphSyncPartSettings(context.ContentItem.ContentType);
+
+            if (syncSettings.PreexistingNode)
+            {
+                _preExistingContentItemVersion.SetContentApiBaseUrl(syncSettings.PreExistingNodeUriPrefix);
+            }
+
             return Task.FromResult(context.GraphValidationHelper.ContentPropertyMatchesNodeProperty(
                 context.SyncNameProvider.ContentIdPropertyName,
                 content,
@@ -50,7 +64,7 @@ namespace DFC.ServiceTaxonomy.GraphSync.GraphSyncers.Parts
                 (contentValue, nodeValue) =>
                     nodeValue is string nodeValueString
                     && Equals((string)contentValue!,
-                        context.SyncNameProvider.IdPropertyValueFromNodeValue(nodeValueString, context.ContentItemVersion))));
+                        context.SyncNameProvider.IdPropertyValueFromNodeValue(nodeValueString, syncSettings.PreexistingNode ? _preExistingContentItemVersion : context.ContentItemVersion))));
         }
     }
 }

--- a/DFC.ServiceTaxonomy.GraphSync/GraphSyncers/Results/ValidateAndRepair/RepairFailure.cs
+++ b/DFC.ServiceTaxonomy.GraphSync/GraphSyncers/Results/ValidateAndRepair/RepairFailure.cs
@@ -6,11 +6,13 @@ namespace DFC.ServiceTaxonomy.GraphSync.GraphSyncers.Results.ValidateAndRepair
     {
         public ContentItem ContentItem { get; set; }
         public string Reason { get; set; }
+        public ValidateType Type { get; }
 
-        public RepairFailure(ContentItem contentItem, string reason)
+        public RepairFailure(ContentItem contentItem, string reason, ValidateType type = ValidateType.Merge)
         {
             ContentItem = contentItem;
             Reason = reason;
+            Type = type;
         }
     }
 }

--- a/DFC.ServiceTaxonomy.GraphSync/GraphSyncers/Results/ValidateAndRepair/ValidateAndRepairResult.cs
+++ b/DFC.ServiceTaxonomy.GraphSync/GraphSyncers/Results/ValidateAndRepair/ValidateAndRepairResult.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using OrchardCore.ContentManagement;
 
 namespace DFC.ServiceTaxonomy.GraphSync.GraphSyncers.Results.ValidateAndRepair
 {
@@ -11,9 +10,9 @@ namespace DFC.ServiceTaxonomy.GraphSync.GraphSyncers.Results.ValidateAndRepair
         public string GraphName { get; }
         public bool DefaultGraph { get; }
 
-        public List<ContentItem> Validated { get; } = new List<ContentItem>();
+        public List<ValidatedContentItem> Validated { get; } = new List<ValidatedContentItem>();
         public List<ValidationFailure> ValidationFailures { get; } = new List<ValidationFailure>();
-        public List<ContentItem> Repaired { get; } = new List<ContentItem>();
+        public List<ValidatedContentItem> Repaired { get; } = new List<ValidatedContentItem>();
         public List<RepairFailure> RepairFailures { get; } = new List<RepairFailure>();
 
         public ValidateAndRepairResult(

--- a/DFC.ServiceTaxonomy.GraphSync/GraphSyncers/Results/ValidateAndRepair/ValidateType.cs
+++ b/DFC.ServiceTaxonomy.GraphSync/GraphSyncers/Results/ValidateAndRepair/ValidateType.cs
@@ -1,0 +1,8 @@
+﻿namespace DFC.ServiceTaxonomy.GraphSync.GraphSyncers.Results.ValidateAndRepair
+{
+    public enum ValidateType
+    {
+        Merge,
+        Delete
+    }
+}

--- a/DFC.ServiceTaxonomy.GraphSync/GraphSyncers/Results/ValidateAndRepair/ValidatedContentItem.cs
+++ b/DFC.ServiceTaxonomy.GraphSync/GraphSyncers/Results/ValidateAndRepair/ValidatedContentItem.cs
@@ -1,0 +1,16 @@
+﻿using OrchardCore.ContentManagement;
+
+namespace DFC.ServiceTaxonomy.GraphSync.GraphSyncers.Results.ValidateAndRepair
+{
+    public class ValidatedContentItem
+    {
+        public ValidatedContentItem(ContentItem contentItem, ValidateType type = ValidateType.Merge)
+        {
+            ContentItem = contentItem;
+            Type = type;
+        }
+
+        public ContentItem ContentItem { get; }
+        public ValidateType Type { get; }
+    }
+}

--- a/DFC.ServiceTaxonomy.GraphSync/GraphSyncers/Results/ValidateAndRepair/ValidationFailure.cs
+++ b/DFC.ServiceTaxonomy.GraphSync/GraphSyncers/Results/ValidateAndRepair/ValidationFailure.cs
@@ -6,19 +6,13 @@ namespace DFC.ServiceTaxonomy.GraphSync.GraphSyncers.Results.ValidateAndRepair
     {
         public ContentItem ContentItem { get; }
         public string Reason { get; }
-        public FailureType Type { get; }
+        public ValidateType Type { get; }
 
-        public ValidationFailure(ContentItem contentItem, string reason, FailureType type = FailureType.Merge)
+        public ValidationFailure(ContentItem contentItem, string reason, ValidateType type = ValidateType.Merge)
         {
             ContentItem = contentItem;
             Reason = reason;
             Type = type;
         }
-    }
-
-    public enum FailureType
-    {
-        Merge,
-        Delete
     }
 }

--- a/DFC.ServiceTaxonomy.GraphSync/GraphSyncers/ValidateAndRepairGraph.cs
+++ b/DFC.ServiceTaxonomy.GraphSync/GraphSyncers/ValidateAndRepairGraph.cs
@@ -137,7 +137,9 @@ namespace DFC.ServiceTaxonomy.GraphSync.GraphSyncers
                             contentItemVersion,
                             contentTypeDefinition,
                             validateFrom,
-                            result);
+                            result,
+                            validationScope);
+
                         if (syncFailures.Any())
                         {
                             await AttemptRepair(syncFailures, contentTypeDefinition, contentItemVersion, result);
@@ -174,7 +176,8 @@ namespace DFC.ServiceTaxonomy.GraphSync.GraphSyncers
             IContentItemVersion contentItemVersion,
             ContentTypeDefinition contentTypeDefinition,
             DateTime lastSynced,
-            ValidateAndRepairResult result)
+            ValidateAndRepairResult result,
+            ValidationScope scope)
         {
             List<ValidationFailure> syncFailures = new List<ValidationFailure>();
 
@@ -204,7 +207,7 @@ namespace DFC.ServiceTaxonomy.GraphSync.GraphSyncers
                         contentItem.ContentType,
                         contentItem.ContentItemId,
                         GraphDescription(_currentGraph!));
-                    result.Validated.Add(contentItem);
+                    result.Validated.Add(new ValidatedContentItem(contentItem));
                 }
                 else
                 {
@@ -216,26 +219,32 @@ namespace DFC.ServiceTaxonomy.GraphSync.GraphSyncers
                 }
             }
 
-            foreach (ContentItem contentItem in deletedContentTypeContentItems)
+            if (scope == ValidationScope.ModifiedSinceLastValidation)
             {
-                (bool validated, string? validationFailureReason) =
-                    await ValidateDeletedContentItem(contentItem, contentTypeDefinition, contentItemVersion);
+                foreach (ContentItem contentItem in deletedContentTypeContentItems)
+                {
+                    (bool validated, string? validationFailureReason) =
+                        await ValidateDeletedContentItem(contentItem, contentTypeDefinition, contentItemVersion);
 
-                if (validated)
-                {
-                    _logger.LogInformation("Sync validation passed for deleted {ContentType} {ContentItemId} in {CurrentGraph}.",
-                        contentItem.ContentType,
-                        contentItem.ContentItemId,
-                        GraphDescription(_currentGraph!));
-                    result.Validated.Add(contentItem);
-                }
-                else
-                {
-                    string message = $"Sync validation failed in {{CurrentGraph}}.{Environment.NewLine}{{validationFailureReason}}.";
-                    _logger.LogWarning(message, GraphDescription(_currentGraph!), validationFailureReason);
-                    ValidationFailure validationFailure = new ValidationFailure(contentItem, validationFailureReason!, FailureType.Delete);
-                    syncFailures.Add(validationFailure);
-                    result.ValidationFailures.Add(validationFailure);
+                    if (validated)
+                    {
+                        _logger.LogInformation(
+                            "Sync validation passed for deleted {ContentType} {ContentItemId} in {CurrentGraph}.",
+                            contentItem.ContentType,
+                            contentItem.ContentItemId,
+                            GraphDescription(_currentGraph!));
+                        result.Validated.Add(new ValidatedContentItem(contentItem, ValidateType.Delete));
+                    }
+                    else
+                    {
+                        string message =
+                            $"Sync validation failed in {{CurrentGraph}}.{Environment.NewLine}{{validationFailureReason}}.";
+                        _logger.LogWarning(message, GraphDescription(_currentGraph!), validationFailureReason);
+                        ValidationFailure validationFailure = new ValidationFailure(contentItem,
+                            validationFailureReason!, ValidateType.Delete);
+                        syncFailures.Add(validationFailure);
+                        result.ValidationFailures.Add(validationFailure);
+                    }
                 }
             }
 
@@ -261,7 +270,7 @@ namespace DFC.ServiceTaxonomy.GraphSync.GraphSyncers
 
             foreach (var failure in syncValidationFailures)
             {
-                if (failure.Type == FailureType.Merge)
+                if (failure.Type == ValidateType.Merge)
                 {
                     await AttemptMergeRepair(contentTypeDefinition, contentItemVersion, result, failure);
                 }
@@ -300,7 +309,7 @@ namespace DFC.ServiceTaxonomy.GraphSync.GraphSyncers
                     failure.ContentItem.ContentType,
                     failure.ContentItem.ContentItemId,
                     GraphDescription(_currentGraph!));
-                result.Repaired.Add(failure.ContentItem);
+                result.Repaired.Add(new ValidatedContentItem(failure.ContentItem));
             }
             else
             {
@@ -336,13 +345,13 @@ namespace DFC.ServiceTaxonomy.GraphSync.GraphSyncers
                     failure.ContentItem.ContentType,
                     failure.ContentItem.ContentItemId,
                     GraphDescription(_currentGraph!));
-                result.Repaired.Add(failure.ContentItem);
+                result.Repaired.Add(new ValidatedContentItem(failure.ContentItem, ValidateType.Delete));
             }
             else
             {
                 string message = $"Repair was unsuccessful.{Environment.NewLine}{{ValidationFailureReason}}.";
                 _logger.LogWarning(message, validationFailureReason);
-                result.RepairFailures.Add(new RepairFailure(failure.ContentItem, validationFailureReason!));
+                result.RepairFailures.Add(new RepairFailure(failure.ContentItem, validationFailureReason!, ValidateType.Delete));
             }
         }
 

--- a/DFC.ServiceTaxonomy.GraphSync/ViewModels/TriggerSyncValidationViewModel.cs
+++ b/DFC.ServiceTaxonomy.GraphSync/ViewModels/TriggerSyncValidationViewModel.cs
@@ -1,9 +1,11 @@
-﻿using DFC.ServiceTaxonomy.GraphSync.GraphSyncers.Interfaces.Results.ValidateAndRepair;
+﻿using DFC.ServiceTaxonomy.GraphSync.GraphSyncers;
+using DFC.ServiceTaxonomy.GraphSync.GraphSyncers.Interfaces.Results.ValidateAndRepair;
 
 namespace DFC.ServiceTaxonomy.GraphSync.ViewModels
 {
     public class TriggerSyncValidationViewModel
     {
         public IValidateAndRepairResults? ValidateAndRepairResults { get; set; }
+        public ValidationScope? Scope { get; set; }
     }
 }

--- a/DFC.ServiceTaxonomy.GraphSync/Views/GraphSync/TriggerSyncValidation.cshtml
+++ b/DFC.ServiceTaxonomy.GraphSync/Views/GraphSync/TriggerSyncValidation.cshtml
@@ -1,6 +1,7 @@
 ﻿@using OrchardCore.ContentManagement
 @using DFC.ServiceTaxonomy.GraphSync.GraphSyncers.Results.ValidateAndRepair
 @using System.Data.SqlTypes
+@using DFC.ServiceTaxonomy.GraphSync.GraphSyncers
 @model TriggerSyncValidationViewModel
 
 @* todo: loop through results and display each *@
@@ -87,73 +88,153 @@
                 }
 
                 // would have thought that embedded ul should be wrapped in li, but that doesn't seem to work -> check other browsers
-                <ul id="results" class="list-group mb-3">
+<ul id="results" class="list-group mb-3">
 
-                    @* copying thead-light *@
-                    <li class="list-group-item" style=" color: #495057; background-color: #e9ecef;">
-                        Instance: #<strong>@graphResult.GraphInstance</strong>, Endpoint: '<strong>@graphResult.EndpointName</strong>', Graph: '<strong>@graphResult.GraphName</strong>'@if(graphResult.DefaultGraph){<text>*</text>}
-                    </li>
+    @* copying thead-light *@
+    <li class="list-group-item" style=" color: #495057; background-color: #e9ecef;">
+        Instance: #<strong>@graphResult.GraphInstance</strong>, Endpoint: '<strong>@graphResult.EndpointName</strong>', Graph: '<strong>@graphResult.GraphName</strong>'@if (graphResult.DefaultGraph)
+        {<text>*</text>}
+    </li>
 
-                    <li href="#validated-@graphResult.EndpointName-@graphResult.GraphName" class="list-group-item d-flex justify-content-between align-items-center" data-toggle="collapse">
-                        <span><i class="fas fa-chevron-right fa-fw"></i> Validated</span>
-                        <span class="badge badge-pill badge-primary">@graphResult.Validated.Count</span>
-                    </li>
-                    <ul class="list-group collapse" id="validated-@graphResult.EndpointName-@graphResult.GraphName">
-                        @foreach (ContentItem contentItem in graphResult.Validated)
-                        {
-                            <li href="#" class="list-group-item d-flex justify-content-between align-items-center">
-                                @{ await ShowContentItem(contentItem); }
-                            </li>
-                        }
-                    </ul>
+    <li href="#validated-@graphResult.EndpointName-@graphResult.GraphName" class="list-group-item d-flex justify-content-between align-items-center" data-toggle="collapse">
+        <span><i class="fas fa-chevron-right fa-fw"></i> Validated</span>
+        <span class="badge badge-pill badge-primary">@graphResult.Validated.Count(x => x.Type == ValidateType.Merge)</span>
+    </li>
+    <ul class="list-group collapse" id="validated-@graphResult.EndpointName-@graphResult.GraphName">
+        @foreach (ValidatedContentItem validated in graphResult.Validated.Where(x => x.Type == ValidateType.Merge))
+        {
+            <li href="#" class="list-group-item d-flex justify-content-between align-items-center">
+                @{ await ShowContentItem(validated.ContentItem); }
+            </li>
+        }
+    </ul>
 
-                    <li href="#failed-validation-@graphResult.EndpointName-@graphResult.GraphName" class="list-group-item d-flex justify-content-between align-items-center" data-toggle="collapse">
-                        <span><i class="fas fa-chevron-right fa-fw"></i> Failed Validation</span>
-                        <span class="badge badge-pill badge-primary">@graphResult.ValidationFailures.Count</span>
-                    </li>
-                    <ul class="list-group collapse" id="failed-validation-@graphResult.EndpointName-@graphResult.GraphName">
-                        @foreach (ValidationFailure validationFailure in graphResult.ValidationFailures)
-                        {
-                            <li href="#valfail-@validationFailure.ContentItem.ContentItemId" class="list-group-item d-flex justify-content-between align-items-center" data-toggle="collapse">
-                                @* todo: user id in results *@
-                                <span><i class="fas fa-chevron-right fa-fw"></i> @{ await ShowContentItem(validationFailure.ContentItem); }</span>
-                            </li>
+    @if (Model.Scope == ValidationScope.ModifiedSinceLastValidation)
+    {
+        <li href="#validateddeletes-@graphResult.EndpointName-@graphResult.GraphName" class="list-group-item d-flex justify-content-between align-items-center" data-toggle="collapse">
+            <span><i class="fas fa-chevron-right fa-fw"></i> Validated Deletes</span>
+            <span class="badge badge-pill badge-primary">@graphResult.Validated.Count(x => x.Type == ValidateType.Delete)</span>
+        </li>
+        <ul class="list-group collapse" id="validateddeletes-@graphResult.EndpointName-@graphResult.GraphName">
+            @foreach (ValidatedContentItem validated in graphResult.Validated.Where(x => x.Type == ValidateType.Delete))
+            {
+                <li href="#" class="list-group-item d-flex justify-content-between align-items-center">
+                    @{ await ShowContentItem(validated.ContentItem, ValidateType.Delete); }
+                </li>
+            }
+        </ul>
+    }
 
-                            <ul class="list-group collapse" id="valfail-@validationFailure.ContentItem.ContentItemId">
-                                <li href="#" class="list-group-item d-flex justify-content-between align-items-center"><pre><code>@validationFailure.Reason</code></pre></li>
-                            </ul>
-                        }
-                    </ul>
+    <li href="#failed-validation-@graphResult.EndpointName-@graphResult.GraphName" class="list-group-item d-flex justify-content-between align-items-center" data-toggle="collapse">
+        <span><i class="fas fa-chevron-right fa-fw"></i> Failed Validation</span>
+        <span class="badge badge-pill badge-primary">@graphResult.ValidationFailures.Count(x => x.Type == ValidateType.Merge)</span>
+    </li>
+    <ul class="list-group collapse" id="failed-validation-@graphResult.EndpointName-@graphResult.GraphName">
+        @foreach (ValidationFailure validationFailure in graphResult.ValidationFailures.Where(x => x.Type == ValidateType.Merge))
+        {
+            <li href="#valfail-@validationFailure.ContentItem.ContentItemId" class="list-group-item d-flex justify-content-between align-items-center" data-toggle="collapse">
+                @* todo: user id in results *@
+                <span><i class="fas fa-chevron-right fa-fw"></i> @{ await ShowContentItem(validationFailure.ContentItem); }</span>
+            </li>
 
-                    <li href="#repaired-@graphResult.EndpointName-@graphResult.GraphName" class="list-group-item d-flex justify-content-between align-items-center" data-toggle="collapse">
-                        <span><i class="fas fa-chevron-right fa-fw"></i> Repaired</span>
-                        <span class="badge badge-pill badge-primary">@graphResult.Repaired.Count</span>
-                    </li>
-                    <ul class="list-group collapse" id="repaired-@graphResult.EndpointName-@graphResult.GraphName">
-                        @foreach (ContentItem contentItem in graphResult.Repaired)
-                        {
-                            <li href="#" class="list-group-item d-flex justify-content-between align-items-center"> @{ await ShowContentItem(contentItem); }</li>
-                        }
-                    </ul>
+            <ul class="list-group collapse" id="valfail-@validationFailure.ContentItem.ContentItemId">
+                <li href="#" class="list-group-item d-flex justify-content-between align-items-center"><pre><code>@validationFailure.Reason</code></pre></li>
+            </ul>
+        }
+    </ul>
 
-                    <li href="#repair-failed-@graphResult.EndpointName-@graphResult.GraphName" class="list-group-item d-flex justify-content-between align-items-center" data-toggle="collapse">
-                        <span><i class="fas fa-chevron-right fa-fw"></i> Repair Failed</span>
-                        <span class="badge badge-pill badge-primary">@graphResult.RepairFailures.Count</span>
-                    </li>
-                    <ul class="list-group collapse" id="repair-failed-@graphResult.EndpointName-@graphResult.GraphName">
-                        @foreach (RepairFailure repairFailure in graphResult.RepairFailures)
-                        {
-                            <li href="repfail-@repairFailure.ContentItem.ContentItemId" class="list-group-item d-flex justify-content-between align-items-center" data-toggle="collapse">
-                                @* todo: user id in results *@
-                                <span><i class="fas fa-chevron-right fa-fw"></i> @{ await ShowContentItem(repairFailure.ContentItem); }</span>
-                            </li>
+    @if (Model.Scope == ValidationScope.ModifiedSinceLastValidation)
+    {
+        <li href="#deletes-failing-validation-@graphResult.EndpointName-@graphResult.GraphName" class="list-group-item d-flex justify-content-between align-items-center" data-toggle="collapse">
+            <span><i class="fas fa-chevron-right fa-fw"></i> Deletes Failing Validation</span>
+            <span class="badge badge-pill badge-primary">@graphResult.ValidationFailures.Count(x => x.Type == ValidateType.Delete)</span>
+        </li>
+        <ul class="list-group collapse" id="deletes-failing-validation-@graphResult.EndpointName-@graphResult.GraphName">
+            @foreach (ValidationFailure validationFailure in graphResult.ValidationFailures.Where(x => x.Type == ValidateType.Delete))
+            {
+                <li href="#valfail-@validationFailure.ContentItem.ContentItemId" class="list-group-item d-flex justify-content-between align-items-center" data-toggle="collapse">
+                    @* todo: user id in results *@
+                    <span>
+                        <i class="fas fa-chevron-right fa-fw"></i>
+                        @{ await ShowContentItem(validationFailure.ContentItem, ValidateType.Delete); }
+                    </span>
+                </li>
 
-                            <ul class="list-group collapse" id="repfail-@repairFailure.ContentItem.ContentItemId">
-                                <li href="#" class="list-group-item d-flex justify-content-between align-items-center"><pre><code>@repairFailure.Reason</code></pre></li>
-                            </ul>
-                        }
-                    </ul>
+                <ul class="list-group collapse" id="valfail-@validationFailure.ContentItem.ContentItemId">
+                    <li href="#" class="list-group-item d-flex justify-content-between align-items-center"><pre><code>@validationFailure.Reason</code></pre></li>
                 </ul>
+            }
+        </ul>
+    }
+
+    <li href="#repaired-@graphResult.EndpointName-@graphResult.GraphName" class="list-group-item d-flex justify-content-between align-items-center" data-toggle="collapse">
+        <span><i class="fas fa-chevron-right fa-fw"></i> Repaired</span>
+        <span class="badge badge-pill badge-primary">@graphResult.Repaired.Count(x => x.Type == ValidateType.Merge)</span>
+    </li>
+    <ul class="list-group collapse" id="repaired-@graphResult.EndpointName-@graphResult.GraphName">
+        @foreach (ValidatedContentItem repaired in graphResult.Repaired.Where(x => x.Type == ValidateType.Merge))
+        {
+            <li href="#" class="list-group-item d-flex justify-content-between align-items-center"> @{ await ShowContentItem(repaired.ContentItem); }</li>
+        }
+    </ul>
+
+    @if (Model.Scope == ValidationScope.ModifiedSinceLastValidation)
+    {
+        <li href="#repaireddeletes-@graphResult.EndpointName-@graphResult.GraphName" class="list-group-item d-flex justify-content-between align-items-center" data-toggle="collapse">
+            <span><i class="fas fa-chevron-right fa-fw"></i> Repaired Deletes</span>
+            <span class="badge badge-pill badge-primary">@graphResult.Repaired.Count(x => x.Type == ValidateType.Delete)</span>
+        </li>
+        <ul class="list-group collapse" id="repaireddeletes-@graphResult.EndpointName-@graphResult.GraphName">
+            @foreach (ValidatedContentItem repaired in graphResult.Repaired.Where(x => x.Type == ValidateType.Delete))
+            {
+                <li href="#" class="list-group-item d-flex justify-content-between align-items-center">
+                    @{ await ShowContentItem(repaired.ContentItem, ValidateType.Delete); }
+                </li>
+            }
+        </ul>
+    }
+
+    <li href="#repair-failed-@graphResult.EndpointName-@graphResult.GraphName" class="list-group-item d-flex justify-content-between align-items-center" data-toggle="collapse">
+        <span><i class="fas fa-chevron-right fa-fw"></i> Repair Failed</span>
+        <span class="badge badge-pill badge-primary">@graphResult.RepairFailures.Count(x => x.Type == ValidateType.Merge)</span>
+    </li>
+    <ul class="list-group collapse" id="repair-failed-@graphResult.EndpointName-@graphResult.GraphName">
+        @foreach (RepairFailure repairFailure in graphResult.RepairFailures.Where(x => x.Type == ValidateType.Merge))
+        {
+            <li href="repfail-@repairFailure.ContentItem.ContentItemId" class="list-group-item d-flex justify-content-between align-items-center" data-toggle="collapse">
+                @* todo: user id in results *@
+                <span><i class="fas fa-chevron-right fa-fw"></i> @{ await ShowContentItem(repairFailure.ContentItem); }</span>
+            </li>
+
+            <ul class="list-group collapse" id="repfail-@repairFailure.ContentItem.ContentItemId">
+                <li href="#" class="list-group-item d-flex justify-content-between align-items-center"><pre><code>@repairFailure.Reason</code></pre></li>
+            </ul>
+        }
+    </ul>
+
+    @if (Model.Scope == ValidationScope.ModifiedSinceLastValidation)
+    {
+        <li href="#deletes-repair-failed-@graphResult.EndpointName-@graphResult.GraphName" class="list-group-item d-flex justify-content-between align-items-center" data-toggle="collapse">
+            <span><i class="fas fa-chevron-right fa-fw"></i> Deletes Failing Repair</span>
+            <span class="badge badge-pill badge-primary">@graphResult.RepairFailures.Count(x => x.Type == ValidateType.Delete)</span>
+        </li>
+        <ul class="list-group collapse" id="deletes-repair-failed-@graphResult.EndpointName-@graphResult.GraphName">
+            @foreach (RepairFailure repairFailure in graphResult.RepairFailures.Where(x => x.Type == ValidateType.Delete))
+            {
+                <li href="repfail-@repairFailure.ContentItem.ContentItemId" class="list-group-item d-flex justify-content-between align-items-center" data-toggle="collapse">
+                    @* todo: user id in results *@
+                    <span><i class="fas fa-chevron-right fa-fw"></i>
+                        @{ await ShowContentItem(repairFailure.ContentItem, ValidateType.Delete); }
+                    </span>
+                </li>
+
+                <ul class="list-group collapse" id="repfail-@repairFailure.ContentItem.ContentItemId">
+                    <li href="#" class="list-group-item d-flex justify-content-between align-items-center"><pre><code>@repairFailure.Reason</code></pre></li>
+                </ul>
+            }
+        </ul>
+    }
+    </ul>
             }
 
             <div class="display-1 text-center" style="color: #FCFCFC"><i class="fab fa-creative-commons-pd-alt"></i></div>
@@ -177,20 +258,35 @@
         }
     }
 
-    private async Task ShowContentItem(ContentItem contentItem)
+    private async Task ShowContentItem(ContentItem contentItem, ValidateType type = ValidateType.Merge)
     {
-        <span><a edit-for="@(contentItem)" target="_blank">
-            <strong>
-                @if (string.IsNullOrWhiteSpace(contentItem.DisplayText))
-                {
-                    <text>Id (No Title): @contentItem.ContentItemId</text>
-                }
-                else
-                {
-                    <text>'@contentItem.DisplayText'</text>
-                }
-            </strong>
-        </a> (<strong>@contentItem.ContentType</strong>)</span>
+        <span>
+            @if (type == ValidateType.Merge)
+            {
+                <a edit-for="@(contentItem)" target="_blank">
+                    @{ await BuildContentItemText(contentItem); }
+                </a>
+            }
+            else
+            {
+                await BuildContentItemText(contentItem);
+            }
+            (<strong>@contentItem.ContentType</strong>)
+        </span>
+    }
+
+    private async Task BuildContentItemText(ContentItem contentItem)
+    {
+        <strong>
+            @if (string.IsNullOrWhiteSpace(contentItem.DisplayText))
+            {
+                <text>Id (No Title): @contentItem.ContentItemId</text>
+            }
+            else
+            {
+                <text>'@contentItem.DisplayText'</text>
+            }
+        </strong>
     }
 #pragma warning restore 1998
 }

--- a/DFC.ServiceTaxonomy.UnitTests/GraphSync/GraphSyncers/Parts/GraphSyncPartGraphSyncerTests/GraphSyncPartGraphSyncerValidateSyncComponentTestsBase.cs
+++ b/DFC.ServiceTaxonomy.UnitTests/GraphSync/GraphSyncers/Parts/GraphSyncPartGraphSyncerTests/GraphSyncPartGraphSyncerValidateSyncComponentTestsBase.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
+using DFC.ServiceTaxonomy.GraphSync.GraphSyncers.ContentItemVersions;
+using DFC.ServiceTaxonomy.GraphSync.GraphSyncers.Interfaces.ContentItemVersions;
 using DFC.ServiceTaxonomy.GraphSync.GraphSyncers.Parts;
 using FakeItEasy;
 using Newtonsoft.Json.Linq;
@@ -17,7 +19,9 @@ namespace DFC.ServiceTaxonomy.UnitTests.GraphSync.GraphSyncers.Parts.GraphSyncPa
             A.CallTo(() => SyncNameProvider.ContentIdPropertyName).Returns(ContentIdPropertyName);
             A.CallTo(() => SyncNameProvider.IdPropertyName()).Returns(NodeTitlePropertyName);
 
-            ContentPartGraphSyncer = new GraphSyncPartGraphSyncer();
+            IPreExistingContentItemVersion preExistingContentItemVersion = new PreExistingContentItemVersion();
+
+            ContentPartGraphSyncer = new GraphSyncPartGraphSyncer(preExistingContentItemVersion);
         }
 
         [Theory]


### PR DESCRIPTION
Covers:

Validate and repair: don't validate deleted items when validating all of a graph
Validate and repair: distinguish between incorrectly-present deleted items when reporting results
Validate and repair - attempting to repair occupation to label relationships with wrong base uri