### PR TITLE
DFCC-1208 Stamp event grid EventTime as UTC now

### DIFF
--- a/DFC.ServiceTaxonomy.Events/Models/ContentEvent.cs
+++ b/DFC.ServiceTaxonomy.Events/Models/ContentEvent.cs
@@ -24,7 +24,7 @@ namespace DFC.ServiceTaxonomy.Events.Models
             //todo: the new activity should be Stop()ed
             Data = new ContentEventData(userId, itemId, contentItem.ContentItemVersionId, contentItem.DisplayText, contentItem.Author, contentItem.ContentType, Activity.Current ?? new Activity(nameof(ContentEvent)).Start());
             EventType = GetEventType(contentEventType);
-            EventTime = (contentItem.ModifiedUtc ?? contentItem.CreatedUtc)!.Value;
+            EventTime = DateTime.UtcNow;
             MetadataVersion = null;
             DataVersion = "1.0";
         }


### PR DESCRIPTION
Rather than using the last modified/created time from the content item.