### PR TITLE
FT2-142 Change 'Not in use' approval filter to 'Will need review' instead

### DIFF
--- a/DFC.ServiceTaxonomy.ContentApproval/Models/ContentReviewStatus.cs
+++ b/DFC.ServiceTaxonomy.ContentApproval/Models/ContentReviewStatus.cs
@@ -4,7 +4,10 @@ namespace DFC.ServiceTaxonomy.ContentApproval.Models
 {
     public enum ContentReviewStatus
     {
-        [Display(Name="Not in review")]
+        // the display names are currently only used by the contents item filter,
+        // so the mismatch between NotInReview & "Will need review" is ok for now.
+        // if we need to use the display name "Not In Review" we could have separate attributes
+        [Display(Name="Will need review")]
         NotInReview,
         [Display(Name="Ready for review")]
         ReadyForReview,

--- a/DFC.ServiceTaxonomy.ContentApproval/Services/ContentApprovalContentsAdminListFilter.cs
+++ b/DFC.ServiceTaxonomy.ContentApproval/Services/ContentApprovalContentsAdminListFilter.cs
@@ -3,6 +3,7 @@ using DFC.ServiceTaxonomy.ContentApproval.Indexes;
 using DFC.ServiceTaxonomy.ContentApproval.Models;
 using DFC.ServiceTaxonomy.ContentApproval.ViewModels;
 using OrchardCore.ContentManagement;
+using OrchardCore.ContentManagement.Records;
 using OrchardCore.Contents.Services;
 using OrchardCore.Contents.ViewModels;
 using OrchardCore.DisplayManagement.ModelBinding;
@@ -19,6 +20,10 @@ namespace DFC.ServiceTaxonomy.ContentApproval.Services
             if (await updater.TryUpdateModelAsync(viewModel, ContentApprovalPart.Prefix)
                 && viewModel.SelectedApprovalStatus.HasValue)
             {
+                if (viewModel.SelectedApprovalStatus == ContentReviewStatus.NotInReview)
+                {
+                    query.With<ContentItemIndex>(x => x.Latest && !x.Published);
+                }
                 query.With<ContentApprovalPartIndex>(i => i.ReviewStatus == (int?)viewModel.SelectedApprovalStatus);
             }
         }

--- a/DeveloperNotes.md
+++ b/DeveloperNotes.md
@@ -654,7 +654,6 @@ dotnet new -i OrchardCore.ProjectTemplates::1.0.0-rc1-12019 --nuget-source https
 | not published        | publish                  |
 | published            | n/a                      |
 
-
 each event comes through as a separate workflow instance. can we 'collate' them into single task call?
 or do we publish multiple events?
 versioning: https://stackoverflow.com/questions/60308183/orchard-core-cms-content-versioning-scheduling-and-audit-trail


### PR DESCRIPTION
Change the Review Status filter option from 'Not in review' to 'Will need review', which shows all items with a Content Approval part and a draft version.