### PR TITLE
FT2-270 publishing fix

### DIFF
--- a/DFC.ServiceTaxonomy.ContentApproval/Shapes/ContentEditShapes.cs
+++ b/DFC.ServiceTaxonomy.ContentApproval/Shapes/ContentEditShapes.cs
@@ -21,23 +21,32 @@ namespace DFC.ServiceTaxonomy.ContentApproval.Shapes
             builder.Describe("Content_Edit").OnDisplaying(context =>
             {
                 dynamic shape = context.Shape;
-                Shape actions = (Shape)shape.Actions;
-                // Hide draft button is item is in review
-                var approvalStatus = ((ContentItem)shape.ContentItem).As<ContentApprovalPart>()?.ReviewStatus ?? ContentReviewStatus.NotInReview;
-                if (approvalStatus == ContentReviewStatus.InReview)
+                ContentItem contentItem = (ContentItem)shape.ContentItem;
+                if (contentItem.Has<ContentApprovalPart>())
                 {
-                    actions.Remove("Content_SaveDraftButton");
-                }
-                // Use must have review permissions to be able to publish
-                // TODO: ideally would use the authorize service here however there are issues with dependent objects already having been disposed of
-                var currentUser = _httpContextAccessor.HttpContext?.User;
-                if (currentUser == null || !currentUser.HasClaim(c =>
-                    Permissions.CanPerformReviewPermissions.CanPerformReviewPermission.ImpliedBy.Any(p =>
-                        p.Name == c.Value)))
-                {
-                    actions.Remove("Content_PublishButton");
+                    Shape actions = (Shape)shape.Actions;
+                    // Hide draft button is item is in review
+                    var approvalStatus = contentItem.As<ContentApprovalPart>()?.ReviewStatus ?? ContentReviewStatus.NotInReview;
+                    if (approvalStatus == ContentReviewStatus.InReview)
+                    {
+                        actions.Remove("Content_SaveDraftButton");
+                    }
+                    // Use must have review permissions to be able to publish
+                    if (!IsValidContentApprovalReviewer())
+                    {
+                        actions.Remove("Content_PublishButton");
+                    }
                 }
             });
+        }
+
+        private bool IsValidContentApprovalReviewer()
+        {
+            // TODO: ideally would use the authorize service here however there are issues with dependent objects already having been disposed of
+            var currentUser = _httpContextAccessor.HttpContext?.User;
+            return currentUser != null && currentUser.HasClaim(c =>
+                Permissions.CanPerformReviewPermissions.CanPerformReviewPermission.ImpliedBy
+                    .Any(p => p.Name == c.Value));
         }
     }
 }


### PR DESCRIPTION
This ensures the removal of publishing buttons only occurs if the content item has a content approval part present 