### PR TITLE
FT2-360 avoid event grid if no graphsyncpart present

### DIFF
--- a/DFC.ServiceTaxonomy.GraphSync/Handlers/EventGridPublishingHandler.cs
+++ b/DFC.ServiceTaxonomy.GraphSync/Handlers/EventGridPublishingHandler.cs
@@ -121,6 +121,12 @@ namespace DFC.ServiceTaxonomy.GraphSync.Handlers
                 return;
             }
 
+            if (context.ContentItem.Content.GraphSyncPart == null)
+            {
+                _logger.LogInformation("Event grid publishing is disabled. No events will be published.");
+                return;
+            }
+
             try
             {
                 IContentItemVersion contentItemVersion = eventType switch

--- a/DFC.ServiceTaxonomy.UnitTests/GraphSync/Handlers/EventGridPublishingHandlerTests.cs
+++ b/DFC.ServiceTaxonomy.UnitTests/GraphSync/Handlers/EventGridPublishingHandlerTests.cs
@@ -69,8 +69,11 @@ namespace DFC.ServiceTaxonomy.UnitTests.GraphSync.Handlers
                 DisplayText = "DisplayText",
                 Author = "Author"
             };
+            this.ContentItem.Content.GraphSyncPart = new JObject();
+
             A.CallTo(() => OrchestrationContext.ContentItem)
                 .Returns(ContentItem);
+
         }
 
         [Fact]


### PR DESCRIPTION
If there is no GraphSyncPart there is no need to update Event Grid as the content item won't be sync'd to Neo4j