### PR TITLE
Apprenticeship Standard now automatically de-linked from linked items when deleted

### DIFF
--- a/DFC.ServiceTaxonomy.CustomEditor/Constants/ContentTypes.cs
+++ b/DFC.ServiceTaxonomy.CustomEditor/Constants/ContentTypes.cs
@@ -9,5 +9,6 @@
         public const string Footer = nameof(Footer);
         public const string SectorLandingPage = nameof(SectorLandingPage);
         public const string JobProfileSector = nameof(JobProfileSector);
+        public const string ApprenticeshipStandard = nameof(ApprenticeshipStandard);
     }
 }

--- a/DFC.ServiceTaxonomy.CustomEditor/Views/ContentEdit_AdditionalActions.cshtml
+++ b/DFC.ServiceTaxonomy.CustomEditor/Views/ContentEdit_AdditionalActions.cshtml
@@ -42,6 +42,7 @@
         @if ((hasDraft || hasPublished) && hasDeletePermission)
         {
             var deleteMessage = contentItem.ContentType == ContentTypes.SOCCode ? "Deleting this code shall lead to removal of this SOC code along with any related SOC Skills Matrix content items? Are you sure you want to delete?" : "Are you sure you want to delete this content item?";
+            deleteMessage = contentItem.ContentType == ContentTypes.ApprenticeshipStandard ? "Deleting this Apprenticeship Standrd will also remove it from all linked items. " + deleteMessage : deleteMessage;
             <div class="btn-group btn-group-approval">
                 <a remove-for="@contentItem" data-url-af="RemoveUrl UnsafeUrl" data-bs-title="@T["Delete"]" data-message="@T[deleteMessage]" data-ok-text="@T["Ok"]" data-cancel-text="@T["Cancel"]" class="btn additional-actions-btn-danger">@T["Delete"]</a>
             </div>

--- a/DFC.ServiceTaxonomy.CustomEditor/Views/ContentEdit_AdditionalActions.cshtml
+++ b/DFC.ServiceTaxonomy.CustomEditor/Views/ContentEdit_AdditionalActions.cshtml
@@ -42,7 +42,7 @@
         @if ((hasDraft || hasPublished) && hasDeletePermission)
         {
             var deleteMessage = contentItem.ContentType == ContentTypes.SOCCode ? "Deleting this code shall lead to removal of this SOC code along with any related SOC Skills Matrix content items? Are you sure you want to delete?" : "Are you sure you want to delete this content item?";
-            deleteMessage = contentItem.ContentType == ContentTypes.ApprenticeshipStandard ? "Deleting this Apprenticeship Standrd will also remove it from all linked items. " + deleteMessage : deleteMessage;
+            deleteMessage = contentItem.ContentType == ContentTypes.ApprenticeshipStandard ? "Deleting this Apprenticeship Standard will also remove it from all linked items. " + deleteMessage : deleteMessage;
             <div class="btn-group btn-group-approval">
                 <a remove-for="@contentItem" data-url-af="RemoveUrl UnsafeUrl" data-bs-title="@T["Delete"]" data-message="@T[deleteMessage]" data-ok-text="@T["Ok"]" data-cancel-text="@T["Cancel"]" class="btn additional-actions-btn-danger">@T["Delete"]</a>
             </div>

--- a/DFC.ServiceTaxonomy.GraphSync/CosmosDb/CosmosDbEndpoint.cs
+++ b/DFC.ServiceTaxonomy.GraphSync/CosmosDb/CosmosDbEndpoint.cs
@@ -509,7 +509,7 @@ namespace DFC.ServiceTaxonomy.GraphSync.CosmosDb
 
                 if (linkedItemFromCosmos == null)
                 {
-                    throw new ValidationException($"{linkedItemFromCosmos}");
+                    throw new ValidationException("Failed to delete Content Item. Linked items from cosmos returned NULL.");
                 }
 
                 Dictionary<string, object> linkedItemLinks = SafeCastToDictionary(linkedItemFromCosmos["_links"]);
@@ -517,7 +517,7 @@ namespace DFC.ServiceTaxonomy.GraphSync.CosmosDb
 
                 if (keysInLinkedItem == null)
                 {
-                    throw new ValidationException($"{keysInLinkedItem}");
+                    throw new ValidationException("Failed to delete Content Item. Keys in linked items returned NULL.");
                 }
 
                 foreach (var key in keysInLinkedItem)

--- a/DFC.ServiceTaxonomy.GraphSync/CosmosDb/CosmosDbEndpoint.cs
+++ b/DFC.ServiceTaxonomy.GraphSync/CosmosDb/CosmosDbEndpoint.cs
@@ -95,8 +95,12 @@ namespace DFC.ServiceTaxonomy.GraphSync.CosmosDb
 
             if (blockOnIncomingLinks && incomingLinks.Any())
             {
-                throw new ValidationException(
-                    $"This content is referenced by {incomingLinks.Count} other {GetItemOrItems(incomingLinks.Count)}");
+                if (!contentType.Contains("apprenticeshipstandard"))
+                {
+                    throw new ValidationException($"This content is referenced by {incomingLinks.Count} other {GetItemOrItems(incomingLinks.Count)}");
+                }
+
+                await RemoveItemFromIncomingLinks(databaseName, incomingLinks, id);
             }
 
             await _cosmosDbService.DeleteItemAsync(databaseName, contentType, id);
@@ -492,6 +496,60 @@ namespace DFC.ServiceTaxonomy.GraphSync.CosmosDb
                 relationshipItem["_links"] = links;
 
                 await _cosmosDbService.UpdateItemAsync(databaseName, relationshipItem);
+            }
+        }
+
+        private async Task RemoveItemFromIncomingLinks(string databaseName, List<Dictionary<string, object>> incomingLinks, Guid itemId)
+        {
+            foreach (var linkedItem in incomingLinks)
+            {
+                string contentTypeOfLinkedItem = (string)linkedItem["contentType"];
+                var linkedItemId = new Guid((string)linkedItem["id"]);
+                var linkedItemFromCosmos = await _cosmosDbService.GetContentItemFromDatabase(databaseName, contentTypeOfLinkedItem, linkedItemId);
+
+                if (linkedItemFromCosmos == null)
+                {
+                    throw new ValidationException($"{linkedItemFromCosmos}");
+                }
+
+                Dictionary<string, object> linkedItemLinks = SafeCastToDictionary(linkedItemFromCosmos["_links"]);
+                var keysInLinkedItem = linkedItemLinks.Keys.Where(key => key.Contains("cont:")).ToList();
+
+                if (keysInLinkedItem == null)
+                {
+                    throw new ValidationException($"{keysInLinkedItem}");
+                }
+
+                foreach (var key in keysInLinkedItem)
+                {
+                    if (CanCastToList(linkedItemLinks[key]))
+                    {
+                        List<Dictionary<string, object>>  listOfItemsInContKey = SafeCastToList(linkedItemLinks[key]);
+                        var itemToRemove = listOfItemsInContKey.FirstOrDefault(dict => dict.ContainsKey("href") && (dict["href"].ToString() ?? "").Contains(itemId.ToString()));
+
+                        if (itemToRemove != null)
+                        {
+                            listOfItemsInContKey.Remove(itemToRemove);
+                            linkedItemLinks[key] = listOfItemsInContKey;
+                            break;
+                        }
+
+                    }
+                    else
+                    {
+                        Dictionary<string, object> itemInContKey = SafeCastToDictionary(linkedItemLinks[key]);
+                        var isIdInCurrentKey = (itemInContKey["href"].ToString() ?? "").Contains(itemId.ToString());
+
+                        if (isIdInCurrentKey)
+                        {
+                            linkedItemLinks.Remove(key);
+                            break;
+                        }
+                    }
+                }
+
+                linkedItemFromCosmos["_links"] = linkedItemLinks;
+                await _cosmosDbService.UpdateItemAsync(databaseName, linkedItemFromCosmos);
             }
         }
 

--- a/DFC.ServiceTaxonomy.Migration/Migrations/ContentItems/AddHeaderContentItem.recipe.json
+++ b/DFC.ServiceTaxonomy.Migration/Migrations/ContentItems/AddHeaderContentItem.recipe.json
@@ -86,21 +86,6 @@
                                 "ContentItemId": "[js:uuid()]",
                                 "ContentItemVersionId": "[js:uuid()]",
                                 "ContentType": "LinkMenuItem",
-                                "DisplayText": "Actions plans",
-                                "Latest": false,
-                                "Published": false,
-                                "Owner": "[js: parameters('AdminUserId')]",
-                                "Author": "[js: parameters('AdminUsername')]",
-                                "LinkMenuItemPart": {
-                                    "Name": "Action plans",
-                                    "Url": "/action-plans"
-                                },
-                                "LinkMenuItem": {}
-                            },
-                            {
-                                "ContentItemId": "[js:uuid()]",
-                                "ContentItemVersionId": "[js:uuid()]",
-                                "ContentType": "LinkMenuItem",
                                 "DisplayText": "Careers advice",
                                 "Latest": false,
                                 "Published": false,


### PR DESCRIPTION
1. Method RemoveItemFromIncomingLinks() which removes given Apprenticeship Standard from all linked items in the cosmos database
2.  Add NULL checks in RemoveItemFromIncomingLinks() to avoid build errors 
3. RemoveItemFromIncomingLinks() called only when item being deleted is an Apprenticeship Standard
4. New text added to deletion message when Apprenticeship Standard is being deleted informing the user that the Apprenticeship Standard will be removed from all linked items.